### PR TITLE
タスクの追加を可能にした

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -1,7 +1,33 @@
-package src
+package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"github.com/kouhei-github/todo-list-cli-tool/todo"
+	"os"
+)
+
+const (
+	todoFile = "./storages/todos.json"
+)
 
 func main() {
-	fmt.Println("Hello Golang")
+	add := flag.Bool("add", false, "タスクを追加する")
+
+	flag.Parse()
+
+	todos := &todo.Todos{}
+
+	switch {
+	case *add:
+		todos.Add("Sample todo")
+		if err := todos.Store(todoFile); err != nil {
+			fmt.Fprintln(os.Stdout, err.Error())
+			os.Exit(0)
+		}
+	default:
+		fmt.Fprintln(os.Stdout, "invalid command")
+		os.Exit(0)
+	}
+
 }

--- a/src/storages/todos.json
+++ b/src/storages/todos.json
@@ -1,1 +1,1 @@
-[{"task":"Sample todo","done":false,"createdAt":"2023-11-17T01:42:30.547822744+09:00","completedAt":"0001-01-01T00:00:00Z"}]
+[{"task":"sample","done":false,"createdAt":"2023-11-17T02:02:02.275531938+09:00","completedAt":"0001-01-01T00:00:00Z"},{"task":"sample2","done":false,"createdAt":"2023-11-17T02:02:03.943000991+09:00","completedAt":"0001-01-01T00:00:00Z"}]

--- a/src/storages/todos.json
+++ b/src/storages/todos.json
@@ -1,0 +1,1 @@
+[{"task":"Sample todo","done":false,"createdAt":"2023-11-17T01:42:30.547822744+09:00","completedAt":"0001-01-01T00:00:00Z"}]

--- a/src/todo/todo.go
+++ b/src/todo/todo.go
@@ -1,0 +1,41 @@
+package todo
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+type item struct {
+	Task        string    `json:"task"`
+	Done        bool      `json:"done"`
+	CreatedAt   time.Time `json:"createdAt"`
+	CompletedAt time.Time `json:"completedAt"`
+}
+
+type Todos []item
+
+func (t *Todos) Add(task string) {
+	todo := item{
+		Task:        task,
+		Done:        false,
+		CreatedAt:   time.Now(),
+		CompletedAt: time.Time{},
+	}
+	*t = append(*t, todo)
+}
+
+func (t *Todos) Store(jsonPath string) error {
+	file, err := os.OpenFile(jsonPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+
+	if err = encoder.Encode(t); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/todo/todo.go
+++ b/src/todo/todo.go
@@ -26,15 +26,23 @@ func (t *Todos) Add(task string) {
 }
 
 func (t *Todos) Store(jsonPath string) error {
-	file, err := os.OpenFile(jsonPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	data, err := json.Marshal(t)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(jsonPath, data, 0644)
+}
+
+func (t *Todos) Load(jsonPath string) error {
+	file, err := os.OpenFile(jsonPath, os.O_RDONLY, 0644)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
-	encoder := json.NewEncoder(file)
+	decoder := json.NewDecoder(file)
 
-	if err = encoder.Encode(t); err != nil {
+	if err = decoder.Decode(t); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
main.goには、TODOSリストをロードする際のエラー処理用の関数と、ユーザー入力を取得する関数があり、その過程でハードコードされたタスクの詳細が削除される。getInput()関数は、コマンドライン引数と標準入力の両方をサポートし、引数が提供されない場合のフォールバックとして標準入力があります。入力がない場合はエラーメッセージが表示される。ユーザー入力の保存中にエラーを捕捉するハンドラも含まれている。

todo.goでは、jsonファイルにtodoを取得・保存するためのLoad()メソッドとStore()メソッドが用意されています。Load()は読み込み専用モードでjsonファイルを開き、それをデコードします。一方、Store()はtodosをマーシャルし、既存のデータを上書きして保存します。以前は、Store() メソッドはエンコーダを使ってデータを保存していましたが、シンプルさと一貫性のために変更されました。

これらの変更により、todo-list-cli-toolとのよりダイナミックなインタラクションが可能になり、ユニークな詳細を持つタスクの追加や、将来の参照のためのこれらのタスクの保存が可能になります。