### PR TITLE
TODOアプリケーションにタスク削除機能を追加

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -18,6 +18,7 @@ const (
 func main() {
 	add := flag.Bool("add", false, "タスクを追加する")
 	complete := flag.Int("complete", 0, "タスクを完了させる")
+	del := flag.Int("del", 0, "タスクを削除する")
 
 	flag.Parse()
 
@@ -42,6 +43,15 @@ func main() {
 		}
 	case *complete > 0 && *complete < len(*todos)+1:
 		if err := todos.Complete(*complete); err != nil {
+			fmt.Fprintln(os.Stdout, err.Error())
+			os.Exit(0)
+		}
+		if err := todos.Store(todoFile); err != nil {
+			fmt.Fprintln(os.Stdout, err.Error())
+			os.Exit(0)
+		}
+	case *del > 0 && *del < len(*todos)+1:
+		if err := todos.Delete(*del); err != nil {
 			fmt.Fprintln(os.Stdout, err.Error())
 			os.Exit(0)
 		}

--- a/src/todo/todo.go
+++ b/src/todo/todo.go
@@ -29,11 +29,21 @@ func (t *Todos) Add(task string) {
 func (t *Todos) Complete(index int) error {
 	todos := *t
 	if index <= 0 || index > len(todos) {
-		return errors.New("invalid insdex")
+		return errors.New("invalid index")
 	}
 
 	todos[index-1].Done = true
 	todos[index-1].CompletedAt = time.Now()
+	return nil
+}
+
+func (t *Todos) Delete(index int) error {
+	todos := *t
+	if index <= 0 || index > len(todos) {
+		return errors.New("invalid index")
+	}
+
+	*t = append(todos[:index-1], todos[index:]...)
 	return nil
 }
 


### PR DESCRIPTION
complete'機能に加え、'del'コマンドラインフラグがメインアプリケーション(main.go)に追加された。また、タスク削除を可能にするために、サポートする'Delete'関数がtodo.goに追加された。Complete'関数と同様に、'Delete'関数でも無効なタスクインデックスに対するエラー処理が行われる。タスクの削除を含む変更は todos.json ファイルに永久に保存されます。